### PR TITLE
OrderRepository에 querydsl 적용2

### DIFF
--- a/src/main/java/com/example/foodordersystem/Entity/Order.java
+++ b/src/main/java/com/example/foodordersystem/Entity/Order.java
@@ -17,7 +17,7 @@ public class Order {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
 
     protected Order() {}

--- a/src/main/java/com/example/foodordersystem/Repository/CustomOrderRepository.java
+++ b/src/main/java/com/example/foodordersystem/Repository/CustomOrderRepository.java
@@ -1,9 +1,14 @@
 package com.example.foodordersystem.Repository;
 
+import com.example.foodordersystem.Entity.Food;
 import com.example.foodordersystem.Entity.Order;
+import com.example.foodordersystem.Entity.OrderItem;
 
 import java.util.List;
 
 public interface CustomOrderRepository {
     List<Order> findAllOrders();
+    List<Food> findFoodById(List<Long> foodIds);
+    void deleteOrderById(Long orderId);
+
 }

--- a/src/main/java/com/example/foodordersystem/Repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/example/foodordersystem/Repository/OrderRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.example.foodordersystem.Repository;
 import com.example.foodordersystem.Entity.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 
 import java.util.List;
 
@@ -27,4 +28,30 @@ public class OrderRepositoryImpl implements CustomOrderRepository{
                 .leftJoin(orderItem.food, food).fetchJoin()
                 .fetch();
     }
+
+    public List<Food> findFoodById(List<Long> foodId) {
+        QFood food = QFood.food;
+
+        return queryFactory
+                .selectFrom(food)
+                .where(food.id.in(foodId))
+                .fetch();
+    }
+
+    @Override
+    @Transactional
+    public void deleteOrderById(Long orderId) {
+        QOrderItem orderItem = QOrderItem.orderItem;
+        QOrder order = QOrder.order;
+
+        queryFactory.delete(orderItem)
+                .where(orderItem.order.id.eq(orderId))
+                .execute();
+
+        queryFactory.delete(order)
+                .where(order.id.eq(orderId))
+                .execute();
+    }
+
+
 }


### PR DESCRIPTION
## 2
주문 삭제기능에 적용

주문을 삭제할때 order와 연관되어있는 orderitem을  각각 delete하기때문에 주문한 개수만큼 비효율적으로 쿼리가 발생한다


![1111111111111111111111111](https://github.com/user-attachments/assets/081d8d54-2d86-44f3-a8e1-e871fb3fada3)


querydsl 적용후 사진

![image](https://github.com/user-attachments/assets/4d6bfc55-74d4-4c7b-8c28-0003e2f56fcb)

